### PR TITLE
feat: add vista gestión de pensums

### DIFF
--- a/src/components/shared/nav/menu.tsx
+++ b/src/components/shared/nav/menu.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import DocenteMenu from '../../../pages/docentePage/docenteIndex';
 import CargasMenu from '../../../pages/cargasPage/cargasIndex';
 import DocentePerfil from "../../../pages/perfilDocente"
+import Pensums from '../../../pages/pensums/';
 import { Home } from '../../../pages/home/home';
 
 
@@ -27,7 +28,7 @@ export const MenuItems: Array<Array<Menu>> = [
         {
             'title': 'Pemsuns',
             'pathTo': '/pemsuns',
-            'component': <>Todas las carrerar</>
+            'component': <Pensums/>
         },
         {
             'title': 'Cargas Academicas',

--- a/src/components/shared/nav/subMenus.tsx
+++ b/src/components/shared/nav/subMenus.tsx
@@ -5,6 +5,9 @@ import CreacionDocente from "../../../pages/docentePage/crearDocente/creacionDoc
 import { Menu } from "./types";
 import MostrarDocentes from "../../../pages/admin/docentes/MostrarDocentes";
 import ModificarDocentes from "../../../pages/admin/docentes/ModificarDocentes";
+import Carreras from "../../../pages/pensums/mostrarPensums/carreras";
+import Laboratorios from "../../../pages/pensums/mostrarPensums/laboratorios";
+import Coprogramaticas from "../../../pages/pensums/mostrarPensums/coprogramaticas";
 
 export const adminMenu: Array<Menu> = [
   {
@@ -63,55 +66,25 @@ export const docenteMenu: Array<Menu> = [
   },
 ];
 
-export const carreras: Array<Menu> = [
+export const pensumMenu: Array<Menu> = [
   {
-    paneId: "SISTEMAS",
-    title: "SISTEMAS",
-    pathTo: "/universidad/sistemas",
-    component: <>Contenido de Sistemas</>,
+    paneId: "Carreras",
+    title: "Carreras",
+    pathTo: "/pensum/carreras",
+    component: <Carreras/>,
   },
   {
-    paneId: "CIVIL",
-    title: "CIVIL",
-    pathTo: "/universidad/civil",
-    component: <>Contenido de Civil</>,
+    paneId: "Laboratorios",
+    title: "Laboratorios",
+    pathTo: "/pensum/laboratorios",
+    component: <Laboratorios/>,
   },
   {
-    paneId: "MEDICINA",
-    title: "MEDICINA",
-    pathTo: "/universidad/medicina",
-    component: <>Contenido de Medicina</>,
-  },
-  {
-    paneId: "PSICOLOGIA",
-    title: "PSICOLOGIA",
-    pathTo: "/universidad/psicologia",
-    component: <>Contenido de Psicología</>,
-  },
-  {
-    paneId: "MERCADOTECNIA",
-    title: "MERCADOTECNIA",
-    pathTo: "/universidad/mercadotecnia",
-    component: <>Contenido de Mercadotecnia</>,
-  },
-  {
-    paneId: "GESTION",
-    title: "GESTION",
-    pathTo: "/universidad/gestion",
-    component: <>Contenido de Gestión</>,
-  },
-  {
-    paneId: "INDUSTRIAL",
-    title: "INDUSTRIAL",
-    pathTo: "/universidad/industrial",
-    component: <>Contenido de Industrial</>,
-  },
-  {
-    paneId: "DERECHO",
-    title: "DERECHO",
-    pathTo: "/universidad/derecho",
-    component: <>Contenido de Derecho</>,
-  },
+    paneId: "Coprogramaticas",
+    title: "Coprogramáticas",
+    pathTo: "/pensum/coprogramaticas",
+    component: <Coprogramaticas/>,
+  }
 ];
 
-export default { adminMenu, cargasMenu, docenteMenu, carreras };
+export default { adminMenu, cargasMenu, docenteMenu, pensumMenu };

--- a/src/pages/pensums/index.tsx
+++ b/src/pages/pensums/index.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import {
+    Container,
+    Nav,
+    NavItem,
+    NavLink,
+    TabContent,
+    TabPane,
+} from "reactstrap";
+import { pensumMenu } from "../../components/shared/nav/subMenus";
+import Breadcrumbs from "../../components/shared/breadcrumb/Breadcrumbs";
+
+export default function Pensums() {
+    const [activePane, setActivePane] = useState<string>(pensumMenu[0].paneId!);
+    const onChangeTab = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        setActivePane(e.currentTarget.name);
+    };
+    const currentTab = pensumMenu.find((item) => item.paneId === activePane);
+
+    return (
+        <div className="align-self-center w-100 px-5">
+            <Breadcrumbs
+                items={[
+                    { title: "Inicio" },
+                    { title: "Pensums" },
+                    { title: currentTab?.title || "" },
+                ]}
+            />
+            <Nav className="mt-5" justified tabs>
+                {pensumMenu.map((item, index) => (
+                    <NavItem key={item.paneId! + index}>
+                        <NavLink
+                            active={activePane === item.paneId}
+                            name={item.paneId}
+                            onClick={onChangeTab}
+                        >
+                            {item.title}
+                        </NavLink>
+                    </NavItem>
+                ))}
+            </Nav>
+            <TabContent className="justify-items-center mt-5" activeTab={activePane}>
+                {pensumMenu.map((item, index) => (
+                    <TabPane
+                        key={item.paneId! + (index + 1) + "Pane"}
+                        tabId={item.paneId}
+                    >
+                        <Container>
+                            {activePane === item.paneId && item.component}
+                        </Container>
+                    </TabPane>
+                ))}
+            </TabContent>
+        </div>
+    );
+}

--- a/src/pages/pensums/mostrarPensums/carreras.tsx
+++ b/src/pages/pensums/mostrarPensums/carreras.tsx
@@ -1,0 +1,406 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "../../../store";
+import { Fetcher as FetcherPensum, Selector as SelectorPensum } from "../../../store/slices/pensums";
+import { Container, Card, CardTitle, Row, Col, Button, CardHeader, CardFooter, ButtonGroup, FormGroup, Label, Input, Form, ModalBody, ModalFooter, Modal, ModalHeader, Spinner } from "reactstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEdit, faPlus, faBan, faCheck } from "@fortawesome/free-solid-svg-icons";
+import NotFound from "../../../components/shared/notFound";
+import { isEmpty } from "lodash";
+
+type ClaseDetail = {
+    id_clase: string;
+    nombre_clase: string;
+    creditos: number;
+    estado: boolean;
+    TipoClase: number;
+    bloque?: number;
+};
+
+type ClasesPorBloque = Record<number, ClaseDetail[]>;
+
+type ModalType = 'create' | 'edit' | 'status';
+
+type ModalState = {
+    isOpen: boolean;
+    type: ModalType | null;
+    currentClase?: ClaseDetail;
+    currentBloque?: number;
+};
+
+type ClaseForm = Omit<ClaseDetail, 'estado'> & {
+    facultadId: string;
+    id_bloque: number;
+};
+
+const facultades: { id: string; nombre: string }[] = [
+    { id: 'IG04001', nombre: 'Ingeniería Civil' },
+    { id: 'LG01002', nombre: 'Derecho' },
+    { id: 'CE03100', nombre: 'Gestión Estrategica de Empresas' },
+    { id: 'IF01002', nombre: 'Ingenieria en Ciencias de la Computación' },
+    { id: 'IG02002', nombre: 'Ingeniería Industrial' },
+    { id: 'MD01102', nombre: 'Medicina' },
+    { id: 'CE02002', nombre: 'Mercadotecnia' },
+    { id: 'PS01001', nombre: 'Psicologia' }
+];
+
+const INITIAL_FORM_STATE: ClaseForm = {
+    id_clase: '',
+    nombre_clase: '',
+    creditos: 0,
+    TipoClase: 1,
+    facultadId: '',
+    id_bloque: 1
+};
+
+const INITIAL_MODAL_STATE: ModalState = {
+    isOpen: false,
+    type: null
+};
+
+export default function Carreras() {
+    const dispatch = useDispatch();
+    const [filtroClase, setFiltroClase] = useState<string>('');
+    const [clasesFiltradas, setClasesFiltradas] = useState<ClasesPorBloque>({});
+    const [clasesPorBloque, setClasesPorBloque] = useState<ClasesPorBloque>({});
+    const [facultadSeleccionada, setFacultadSeleccionada] = useState<string>('IG04001');
+    const [modal, setModal] = useState<ModalState>(INITIAL_MODAL_STATE);
+    const [formData, setFormData] = useState<ClaseForm>(INITIAL_FORM_STATE);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+
+    const clases = useSelector(SelectorPensum.getClases);
+    const carreras = useSelector(SelectorPensum.getCarreras);
+
+    const loadData = async (facultadId: string) => {
+        setIsLoading(true);
+        try {
+            await Promise.all([
+                dispatch(FetcherPensum.getClases({ url: "/pensum/getPensum?TipoClase=1" })),
+                dispatch(FetcherPensum.getCarreras({ url: `/pensum/getPensumBy?facultadId=${facultadId}` }))
+            ]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadData(facultadSeleccionada);
+    }, []);
+
+    useEffect(() => {
+        if (!clases?.length || !carreras?.length) return;
+
+        const clasesConBloque = clases.map(clase => ({
+            ...clase,
+            bloque: carreras.find(c => c.id_clase === clase.id_clase)?.id_bloque
+        }));
+
+        const porBloque = clasesConBloque.reduce<ClasesPorBloque>((acc, clase) => {
+            if (clase.bloque) {
+                if (!acc[clase.bloque]) {
+                    acc[clase.bloque] = [];
+                }
+                acc[clase.bloque].push(clase);
+            }
+            return acc;
+        }, {});
+
+        setClasesPorBloque(porBloque);
+        setClasesFiltradas(porBloque);
+    }, [clases, carreras]);
+
+    const handleOpenModal = (type: ModalType, bloque?: number, clase?: ClaseDetail) => {
+        const newFormData = type === 'create'
+            ? { ...INITIAL_FORM_STATE, id_bloque: bloque || 1, facultadId: facultadSeleccionada }
+            : type === 'edit' && clase
+                ? {
+                    id_clase: clase.id_clase,
+                    nombre_clase: clase.nombre_clase,
+                    creditos: clase.creditos,
+                    TipoClase: clase.TipoClase,
+                    facultadId: facultadSeleccionada,
+                    id_bloque: clase.bloque || 1
+                }
+                : INITIAL_FORM_STATE;
+
+        setFormData(newFormData);
+        setModal({ isOpen: true, type, currentClase: clase, currentBloque: bloque });
+    };
+
+    const handleCloseModal = () => {
+        setModal(INITIAL_MODAL_STATE);
+        setFormData(INITIAL_FORM_STATE);
+    };
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        const parsedValue = ['creditos', 'id_bloque'].includes(name) ? parseInt(value) : value;
+        setFormData(prev => ({ ...prev, [name]: parsedValue }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsLoading(true);
+
+        try {
+            const actions = {
+                create: () => dispatch(FetcherPensum.insertClase({
+                    url: '/pensum/insert',
+                    data: formData
+                })),
+                edit: () => modal.currentClase && dispatch(FetcherPensum.updateClase({
+                    url: `/pensum/update?id_clase=${modal.currentClase.id_clase}`,
+                    data: formData
+                })),
+                status: () => modal.currentClase && dispatch(FetcherPensum.updateClase({
+                    url: `/pensum/updateStatus?id_clase=${modal.currentClase.id_clase}`,
+                }))
+            };
+
+            if (modal.type && actions[modal.type]) {
+                await actions[modal.type]();
+                await loadData(facultadSeleccionada);
+                handleCloseModal();
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleFiltroChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const filtro = e.target.value.toLowerCase();
+        setFiltroClase(filtro);
+
+        if (!filtro) {
+            setClasesFiltradas(clasesPorBloque);
+            return;
+        }
+
+        const bloquesFiltrados = Object.entries(clasesPorBloque).reduce<ClasesPorBloque>((acc, [bloque, clases]) => {
+            const clasesFiltradas = clases.filter(clase =>
+                clase.nombre_clase.toLowerCase().includes(filtro) ||
+                clase.id_clase.toLowerCase().includes(filtro)
+            );
+
+            if (clasesFiltradas.length) {
+                acc[parseInt(bloque)] = clasesFiltradas;
+            }
+            return acc;
+        }, {});
+
+        setClasesFiltradas(bloquesFiltrados);
+    };
+
+    const handleFacultadChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const nuevaFacultad = e.target.value;
+        setFacultadSeleccionada(nuevaFacultad);
+        loadData(nuevaFacultad);
+    };
+
+    return (
+        <Container>
+            <h4 className="mb-3">
+                {facultades.find(f => f.id === facultadSeleccionada)?.nombre || 'Plan de Estudios'}
+            </h4>
+            <Form>
+                <Row>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="facultadId">Facultad</Label>
+                            <Input
+                                id="facultadId"
+                                name="facultad"
+                                type="select"
+                                value={facultadSeleccionada}
+                                onChange={handleFacultadChange}
+                            >
+                                {facultades.map(facultad => (
+                                    <option key={facultad.id} value={facultad.id}>
+                                        {facultad.nombre}
+                                    </option>
+                                ))}
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="periodoId">Periodo</Label>
+                            <Input
+                                id="periodoId"
+                                name="periodo"
+                                type="select"
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="filtroClaseId">Buscar Clase</Label>
+                            <Input
+                                id="filtroClaseId"
+                                name="filtroClase"
+                                placeholder="Matemáticas"
+                                type="text"
+                                value={filtroClase}
+                                onChange={handleFiltroChange}
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="docenteId">Buscar Docente</Label>
+                            <Input
+                                id="docenteId"
+                                name="docente"
+                                placeholder="cargon"
+                                type="text"
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                </Row>
+            </Form>
+            
+            {isLoading ? (
+                <div className="text-center my-5">
+                    <Spinner color="primary">
+                        Loading...
+                    </Spinner>
+                </div>
+            ) : (
+                isEmpty(clasesFiltradas) ? (
+                    <NotFound />
+                ) : (
+                    Object.entries(clasesFiltradas).map(([bloque, clases]) => (
+                        <Card body key={bloque} className={"mb-4"}>
+                            <CardHeader className={"mb-3"} tag={"h4"}>Bloque {bloque}</CardHeader>
+                            <Row>
+                                {clases.map((clase) => (
+                                    <Col key={clase.id_clase} md={3} className={"mb-3"}>
+                                        <Card>
+                                            <CardHeader>
+                                                <h6 className={"text-muted mb-0"}> {clase.id_clase} </h6>
+                                                <h5 className={"mb-0"}>{clase.nombre_clase}</h5>
+                                                <h6 className={"text-muted mb-0"}> Créditos: {clase.creditos} </h6>
+                                            </CardHeader>
+                                            <CardFooter>
+                                                <ButtonGroup>
+                                                    <Button color="primary" onClick={() => {/*Implementar creación*/ }}><FontAwesomeIcon icon={faPlus} /> </Button>
+                                                    <Button
+                                                        color={"success"}
+                                                        onClick={() => handleOpenModal('edit', parseInt(bloque), clase)}
+                                                    >
+                                                        <FontAwesomeIcon icon={faEdit} />
+                                                    </Button>
+                                                    <Button
+                                                        color={clase.estado ? "warning" : "info"}
+                                                        onClick={() => handleOpenModal('status', parseInt(bloque), clase)}
+                                                        title={clase.estado ? "Desactivar" : "Activar"}
+                                                    >
+                                                        <FontAwesomeIcon icon={clase.estado ? faBan : faCheck} />
+                                                    </Button>
+                                                </ButtonGroup>
+                                            </CardFooter>
+                                        </Card>
+                                    </Col>
+                                ))}
+                                <Col md={3} className={"mb-3"}>
+                                    <Card>
+                                        <CardHeader>
+                                            <CardTitle tag={"h5"}> AGREGAR CLASE </CardTitle>
+                                        </CardHeader>
+                                        <CardFooter>
+                                            <Button
+                                                color={"primary"}
+                                                onClick={() => handleOpenModal('create', parseInt(bloque))}
+                                            >
+                                                <FontAwesomeIcon icon={faPlus} />
+                                            </Button>
+                                        </CardFooter>
+                                    </Card>
+                                </Col>
+                            </Row>
+                        </Card>
+                    ))
+                )
+            )}
+            <Modal isOpen={modal.isOpen} toggle={handleCloseModal}>
+                <ModalHeader toggle={handleCloseModal}>
+                    {modal.type === 'create' && 'Crear Nueva Clase'}
+                    {modal.type === 'edit' && 'Editar Clase'}
+                    {modal.type === 'status' && 'Cambiar Estado de Clase'}
+                </ModalHeader>
+                <Form onSubmit={handleSubmit}>
+                    <ModalBody>
+                        {modal.type === 'status' ? (
+                            <div className="text-center">
+                                <h5>¿Está seguro que desea {modal.currentClase?.estado ? 'desactivar' : 'activar'} la clase?</h5>
+                                <p className="mb-0">Clase: {modal.currentClase?.nombre_clase}</p>
+                                <p className="mb-0">Código: {modal.currentClase?.id_clase}</p>
+                                <p className="mb-0">Créditos: {modal.currentClase?.creditos}</p>
+                            </div>
+                        ) : (
+                            <>
+                                <FormGroup>
+                                    <Label for="id_clase">Código de Clase</Label>
+                                    <Input
+                                        id="id_clase"
+                                        name="id_clase"
+                                        value={formData.id_clase}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="nombre_clase">Nombre de Clase</Label>
+                                    <Input
+                                        id="nombre_clase"
+                                        name="nombre_clase"
+                                        value={formData.nombre_clase}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="creditos">Créditos</Label>
+                                    <Input
+                                        id="creditos"
+                                        name="creditos"
+                                        type="number"
+                                        value={formData.creditos}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="id_bloque">Bloque</Label>
+                                    <Input
+                                        id="id_bloque"
+                                        name="id_bloque"
+                                        type="number"
+                                        value={formData.id_bloque}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                            </>
+                        )}
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button color="secondary" onClick={handleCloseModal}>
+                            Cancelar
+                        </Button>
+                        <Button
+                            color={modal.type === 'status' ? (modal.currentClase?.estado ? 'warning' : 'success') : 'primary'}
+                            type="submit"
+                        >
+                            {modal.type === 'create' && 'Crear'}
+                            {modal.type === 'edit' && 'Guardar'}
+                            {modal.type === 'status' && (modal.currentClase?.estado ? 'Desactivar' : 'Activar')}
+                        </Button>
+                    </ModalFooter>
+                </Form>
+            </Modal>
+        </Container>
+    );
+}

--- a/src/pages/pensums/mostrarPensums/coprogramaticas.tsx
+++ b/src/pages/pensums/mostrarPensums/coprogramaticas.tsx
@@ -1,0 +1,394 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "../../../store";
+import { Fetcher as FetcherPensum, Selector as SelectorPensum } from "../../../store/slices/pensums";
+import { Container, Card, CardTitle, Row, Col, Button, CardHeader, CardFooter, ButtonGroup, FormGroup, Label, Input, Form, ModalBody, ModalFooter, Modal, ModalHeader, Spinner } from "reactstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEdit, faPlus, faBan, faCheck } from "@fortawesome/free-solid-svg-icons";
+import NotFound from "../../../components/shared/notFound";
+import { isEmpty } from "lodash";
+
+type ClaseDetail = {
+    id_clase: string;
+    nombre_clase: string;
+    creditos: number;
+    estado: boolean;
+    TipoClase: number;
+    bloque?: number;
+};
+
+type ClasesPorBloque = Record<number, ClaseDetail[]>;
+
+type ModalType = 'create' | 'edit' | 'status';
+
+type ModalState = {
+    isOpen: boolean;
+    type: ModalType | null;
+    currentClase?: ClaseDetail;
+    currentBloque?: number;
+};
+
+type ClaseForm = Omit<ClaseDetail, 'estado'> & {
+    facultadId: string;
+    id_bloque: number;
+};
+
+const facultades: { id: string; nombre: string }[] = [
+    { id: 'IDIN01001', nombre: 'Diplomado Ingles' },
+    { id: 'COP', nombre: 'Coprogramaticas' },
+];
+
+const INITIAL_FORM_STATE: ClaseForm = {
+    id_clase: '',
+    nombre_clase: '',
+    creditos: 0,
+    TipoClase: 1,
+    facultadId: '',
+    id_bloque: 1
+};
+
+const INITIAL_MODAL_STATE: ModalState = {
+    isOpen: false,
+    type: null
+};
+
+export default function Coprogramaticas() {
+    const dispatch = useDispatch();
+    const [filtroClase, setFiltroClase] = useState<string>('');
+    const [clasesFiltradas, setClasesFiltradas] = useState<ClasesPorBloque>({});
+    const [clasesPorBloque, setClasesPorBloque] = useState<ClasesPorBloque>({});
+    const [facultadSeleccionada, setFacultadSeleccionada] = useState<string>('IDIN01001');
+    const [modal, setModal] = useState<ModalState>(INITIAL_MODAL_STATE);
+    const [formData, setFormData] = useState<ClaseForm>(INITIAL_FORM_STATE);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+
+    const clases = useSelector(SelectorPensum.getClases);
+    const carreras = useSelector(SelectorPensum.getCarreras);
+
+    const getTipoClase = (facultadId: string) => {
+        return facultadId === 'IDIN01001' ? 2 : 4;
+    };
+
+    const loadData = async (facultadId: string) => {
+        setIsLoading(true);
+        try {
+            const tipoClase = getTipoClase(facultadId);
+            await Promise.all([
+                dispatch(FetcherPensum.getClases({ url: `/pensum/getPensum?TipoClase=${tipoClase}` })),
+                dispatch(FetcherPensum.getCarreras({ url: `/pensum/getPensumBy?facultadId=${facultadId}` }))
+            ]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadData(facultadSeleccionada);
+    }, []);
+
+    useEffect(() => {
+        if (!clases?.length || !carreras?.length) return;
+
+        const clasesConBloque = clases.map(clase => ({
+            ...clase,
+            bloque: carreras.find(c => c.id_clase === clase.id_clase)?.id_bloque || 1
+        }));
+
+        const todasLasClases: ClasesPorBloque = {
+            1: clasesConBloque
+        };
+
+        setClasesPorBloque(todasLasClases);
+        setClasesFiltradas(todasLasClases);
+    }, [clases, carreras]);
+
+    const handleOpenModal = (type: ModalType, bloque?: number, clase?: ClaseDetail) => {
+        const tipoClase = getTipoClase(facultadSeleccionada);
+        const newFormData = type === 'create' 
+            ? { ...INITIAL_FORM_STATE, id_bloque: bloque || 1, facultadId: facultadSeleccionada }
+            : type === 'edit' && clase
+                ? {
+                    id_clase: clase.id_clase,
+                    nombre_clase: clase.nombre_clase,
+                    creditos: clase.creditos,
+                    TipoClase: tipoClase,
+                    facultadId: facultadSeleccionada,
+                    id_bloque: clase.bloque || 1
+                }
+                : INITIAL_FORM_STATE;
+
+        setFormData(newFormData);
+        setModal({ isOpen: true, type, currentClase: clase, currentBloque: bloque });
+    };
+
+    const handleCloseModal = () => {
+        setModal(INITIAL_MODAL_STATE);
+        setFormData(INITIAL_FORM_STATE);
+    };
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        const parsedValue = ['creditos', 'id_bloque'].includes(name) ? parseInt(value) : value;
+        setFormData(prev => ({ ...prev, [name]: parsedValue }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsLoading(true);
+        
+        try {
+            const actions = {
+                create: () => dispatch(FetcherPensum.insertClase({
+                    url: '/pensum/insert',
+                    data: formData
+                })),
+                edit: () => modal.currentClase && dispatch(FetcherPensum.updateClase({
+                    url: `/pensum/update?id_clase=${modal.currentClase.id_clase}`,
+                    data: formData
+                })),
+                status: () => modal.currentClase && dispatch(FetcherPensum.updateClase({
+                    url: `/pensum/updateStatus?id_clase=${modal.currentClase.id_clase}`,
+                }))
+            };
+
+            if (modal.type && actions[modal.type]) {
+                await actions[modal.type]();
+                await loadData(facultadSeleccionada);
+                handleCloseModal();
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleFiltroChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const filtro = e.target.value.toLowerCase();
+        setFiltroClase(filtro);
+
+        if (!filtro) {
+            setClasesFiltradas(clasesPorBloque);
+            return;
+        }
+
+        const bloquesFiltrados = Object.entries(clasesPorBloque).reduce<ClasesPorBloque>((acc, [bloque, clases]) => {
+            const clasesFiltradas = clases.filter(clase =>
+                clase.nombre_clase.toLowerCase().includes(filtro) ||
+                clase.id_clase.toLowerCase().includes(filtro)
+            );
+
+            if (clasesFiltradas.length) {
+                acc[parseInt(bloque)] = clasesFiltradas;
+            }
+            return acc;
+        }, {});
+
+        setClasesFiltradas(bloquesFiltrados);
+    };
+
+    const handleFacultadChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const nuevaFacultad = e.target.value;
+        setFacultadSeleccionada(nuevaFacultad);
+        loadData(nuevaFacultad);
+    };
+
+    return (
+        <Container>
+            <h4 className="mb-3">
+                {facultades.find(f => f.id === facultadSeleccionada)?.nombre || 'Plan de Estudios'}
+            </h4>
+            <Form>
+                <Row>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="facultadId">Facultad</Label>
+                            <Input
+                                id="facultadId"
+                                name="facultad"
+                                type="select"
+                                value={facultadSeleccionada}
+                                onChange={handleFacultadChange}
+                            >
+                                {facultades.map(facultad => (
+                                    <option key={facultad.id} value={facultad.id}>
+                                        {facultad.nombre}
+                                    </option>
+                                ))}
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="periodoId">Periodo</Label>
+                            <Input
+                                id="periodoId"
+                                name="periodo"
+                                type="select"
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="filtroClaseId">Buscar Clase</Label>
+                            <Input
+                                id="filtroClaseId"
+                                name="filtroClase"
+                                placeholder="Matemáticas"
+                                type="text"
+                                value={filtroClase}
+                                onChange={handleFiltroChange}
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="docenteId">Buscar Docente</Label>
+                            <Input
+                                id="docenteId"
+                                name="docente"
+                                placeholder="cargon"
+                                type="text"
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                </Row>
+            </Form>
+
+            {isLoading ? (
+                <div className="text-center my-5">
+                    <Spinner color="primary">
+                        Loading...
+                    </Spinner>
+                </div>
+            ) : (
+                isEmpty(clasesFiltradas) ? (
+                    <NotFound />
+                ) : (
+                    <Card body className={"mb-4"}>
+                        <Row>
+                            {clasesFiltradas[1]?.map((clase) => (
+                                <Col key={clase.id_clase} md={3} className={"mb-3"}>
+                                    <Card>
+                                        <CardHeader>
+                                            <h6 className={"text-muted mb-0"}> {clase.id_clase} </h6>
+                                            <h5 className="mb-0">{clase.nombre_clase}</h5>
+                                            <h6 className={"text-muted mb-0"}> Créditos: {clase.creditos} </h6>
+                                        </CardHeader>
+                                        <CardFooter>
+                                            <ButtonGroup>
+                                                <Button color="primary" onClick={() => {/*Implementar creación*/ }}><FontAwesomeIcon icon={faPlus} /> </Button>
+                                                <Button
+                                                    color={"success"}
+                                                    onClick={() => handleOpenModal('edit', 1, clase)}
+                                                >
+                                                    <FontAwesomeIcon icon={faEdit} />
+                                                </Button>
+                                                <Button
+                                                    color={clase.estado ? "warning" : "info"}
+                                                    onClick={() => handleOpenModal('status', 1, clase)}
+                                                    title={clase.estado ? "Desactivar" : "Activar"}
+                                                >
+                                                    <FontAwesomeIcon icon={clase.estado ? faBan : faCheck} />
+                                                </Button>
+                                            </ButtonGroup>
+                                        </CardFooter>
+                                    </Card>
+                                </Col>
+                            ))}
+                            <Col md={3} className={"mb-3"}>
+                                <Card>
+                                    <CardHeader>
+                                        <CardTitle tag={"h5"}> AGREGAR CLASE </CardTitle>
+                                    </CardHeader>
+                                    <CardFooter>
+                                        <Button color="primary" onClick={() => handleOpenModal('create', 1)}>
+                                            <FontAwesomeIcon icon={faPlus} />
+                                        </Button>
+                                    </CardFooter>
+                                </Card>
+                            </Col>
+                        </Row>
+                    </Card>
+                )
+            )}
+            <Modal isOpen={modal.isOpen} toggle={handleCloseModal}>
+                <ModalHeader toggle={handleCloseModal}>
+                    {modal.type === 'create' && 'Crear Nueva Clase'}
+                    {modal.type === 'edit' && 'Editar Clase'}
+                    {modal.type === 'status' && 'Cambiar Estado de Clase'}
+                </ModalHeader>
+                <Form onSubmit={handleSubmit}>
+                    <ModalBody>
+                        {modal.type === 'status' ? (
+                            <div className="text-center">
+                                <h5>¿Está seguro que desea {modal.currentClase?.estado ? 'desactivar' : 'activar'} la clase?</h5>
+                                <p className="mb-0">Clase: {modal.currentClase?.nombre_clase}</p>
+                                <p className="mb-0">Código: {modal.currentClase?.id_clase}</p>
+                                <p className="mb-0">Créditos: {modal.currentClase?.creditos}</p>
+                            </div>
+                        ) : (
+                            < >
+                                <FormGroup>
+                                    <Label for="id_clase">Código de Clase</Label>
+                                    <Input
+                                        id="id_clase"
+                                        name="id_clase"
+                                        value={formData.id_clase}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="nombre_clase">Nombre de Clase</Label>
+                                    <Input
+                                        id="nombre_clase"
+                                        name="nombre_clase"
+                                        value={formData.nombre_clase}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="creditos">Créditos</Label>
+                                    <Input
+                                        id="creditos"
+                                        name="creditos"
+                                        type="number"
+                                        value={formData.creditos}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="id_bloque">Bloque</Label>
+                                    <Input
+                                        id="id_bloque"
+                                        name="id_bloque"
+                                        type="number"
+                                        value={formData.id_bloque}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                            </>
+                        )}
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button color="secondary" onClick={handleCloseModal}>
+                            Cancelar
+                        </Button>
+                        <Button
+                            color={modal.type === 'status' ? (modal.currentClase?.estado ? 'warning' : 'success') : 'primary'}
+                            type="submit"
+                        >
+                            {modal.type === 'create' && 'Crear'}
+                            {modal.type === 'edit' && 'Guardar'}
+                            {modal.type === 'status' && (modal.currentClase?.estado ? 'Desactivar' : 'Activar')}
+                        </Button>
+                    </ModalFooter>
+                </Form>
+            </Modal>
+        </Container>
+    );
+}

--- a/src/pages/pensums/mostrarPensums/laboratorios.tsx
+++ b/src/pages/pensums/mostrarPensums/laboratorios.tsx
@@ -1,0 +1,401 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "../../../store";
+import { Fetcher as FetcherPensum, Selector as SelectorPensum } from "../../../store/slices/pensums";
+import { Container, Card, CardTitle, Row, Col, Button, CardHeader, CardFooter, ButtonGroup, FormGroup, Label, Input, Form, ModalBody, ModalFooter, Modal, ModalHeader, Spinner } from "reactstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEdit, faPlus, faBan, faCheck } from "@fortawesome/free-solid-svg-icons";
+import NotFound from "../../../components/shared/notFound";
+import { isEmpty } from "lodash";
+
+type ClaseDetail = {
+    id_clase: string;
+    nombre_clase: string;
+    creditos: number;
+    estado: boolean;
+    TipoClase: number;
+    bloque?: number;
+};
+
+type ClasesPorBloque = Record<number, ClaseDetail[]>;
+
+type ModalType = 'create' | 'edit' | 'status';
+
+type ModalState = {
+    isOpen: boolean;
+    type: ModalType | null;
+    currentClase?: ClaseDetail;
+    currentBloque?: number;
+};
+
+type ClaseForm = Omit<ClaseDetail, 'estado'> & {
+    facultadId: string;
+    id_bloque: number;
+};
+
+const facultades: { id: string; nombre: string }[] = [
+    { id: 'IG04001', nombre: 'Ingeniería Civil' },
+    { id: 'IF01002', nombre: 'Ingenieria en Ciencias de la Computación' },
+    { id: 'IG02002', nombre: 'Ingeniería Industrial' },
+    { id: 'MD01102', nombre: 'Medicina' },
+];
+
+const INITIAL_FORM_STATE: ClaseForm = {
+    id_clase: '',
+    nombre_clase: '',
+    creditos: 0,
+    TipoClase: 3,
+    facultadId: '',
+    id_bloque: 1
+};
+
+const INITIAL_MODAL_STATE: ModalState = {
+    isOpen: false,
+    type: null
+};
+
+export default function Laboratorios() {
+    const dispatch = useDispatch();
+    const [filtroClase, setFiltroClase] = useState<string>('');
+    const [clasesFiltradas, setClasesFiltradas] = useState<ClasesPorBloque>({});
+    const [clasesPorBloque, setClasesPorBloque] = useState<ClasesPorBloque>({});
+    const [facultadSeleccionada, setFacultadSeleccionada] = useState<string>('IG04001');
+    const [modal, setModal] = useState<ModalState>(INITIAL_MODAL_STATE);
+    const [formData, setFormData] = useState<ClaseForm>(INITIAL_FORM_STATE);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+
+    const clases = useSelector(SelectorPensum.getClases);
+    const carreras = useSelector(SelectorPensum.getCarreras);
+
+    const loadData = async (facultadId: string) => {
+        setIsLoading(true);
+        try {
+            await Promise.all([
+                dispatch(FetcherPensum.getClases({ url: "/pensum/getPensum?TipoClase=3" })),
+                dispatch(FetcherPensum.getCarreras({ url: `/pensum/getPensumBy?facultadId=${facultadId}` }))
+            ]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadData(facultadSeleccionada);
+    }, []);
+
+    useEffect(() => {
+        if (!clases?.length || !carreras?.length) return;
+
+        const clasesConBloque = clases.map(clase => ({
+            ...clase,
+            bloque: carreras.find(c => c.id_clase === clase.id_clase)?.id_bloque
+        }));
+
+        const porBloque = clasesConBloque.reduce<ClasesPorBloque>((acc, clase) => {
+            if (clase.bloque) {
+                if (!acc[clase.bloque]) {
+                    acc[clase.bloque] = [];
+                }
+                acc[clase.bloque].push(clase);
+            }
+            return acc;
+        }, {});
+
+        setClasesPorBloque(porBloque);
+        setClasesFiltradas(porBloque);
+    }, [clases, carreras]);
+
+    const handleOpenModal = (type: ModalType, bloque?: number, clase?: ClaseDetail) => {
+        const newFormData = type === 'create'
+            ? { ...INITIAL_FORM_STATE, id_bloque: bloque || 1, facultadId: facultadSeleccionada }
+            : type === 'edit' && clase
+                ? {
+                    id_clase: clase.id_clase,
+                    nombre_clase: clase.nombre_clase,
+                    creditos: clase.creditos,
+                    TipoClase: clase.TipoClase,
+                    facultadId: facultadSeleccionada,
+                    id_bloque: clase.bloque || 1
+                }
+                : INITIAL_FORM_STATE;
+
+        setFormData(newFormData);
+        setModal({ isOpen: true, type, currentClase: clase, currentBloque: bloque });
+    };
+
+    const handleCloseModal = () => {
+        setModal(INITIAL_MODAL_STATE);
+        setFormData(INITIAL_FORM_STATE);
+    };
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        const parsedValue = ['creditos', 'id_bloque'].includes(name) ? parseInt(value) : value;
+        setFormData(prev => ({ ...prev, [name]: parsedValue }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsLoading(true);
+
+        try {
+            const actions = {
+                create: () => dispatch(FetcherPensum.insertClase({
+                    url: '/pensum/insert',
+                    data: formData
+                })),
+                edit: () => modal.currentClase && dispatch(FetcherPensum.updateClase({
+                    url: `/pensum/update?id_clase=${modal.currentClase.id_clase}`,
+                    data: formData
+                })),
+                status: () => modal.currentClase && dispatch(FetcherPensum.updateClase({
+                    url: `/pensum/updateStatus?id_clase=${modal.currentClase.id_clase}`,
+                }))
+            };
+
+            if (modal.type && actions[modal.type]) {
+                await actions[modal.type]();
+                await loadData(facultadSeleccionada);
+                handleCloseModal();
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleFiltroChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const filtro = e.target.value.toLowerCase();
+        setFiltroClase(filtro);
+
+        if (!filtro) {
+            setClasesFiltradas(clasesPorBloque);
+            return;
+        }
+
+        const bloquesFiltrados = Object.entries(clasesPorBloque).reduce<ClasesPorBloque>((acc, [bloque, clases]) => {
+            const clasesFiltradas = clases.filter(clase =>
+                clase.nombre_clase.toLowerCase().includes(filtro) ||
+                clase.id_clase.toLowerCase().includes(filtro)
+            );
+
+            if (clasesFiltradas.length) {
+                acc[parseInt(bloque)] = clasesFiltradas;
+            }
+            return acc;
+        }, {});
+
+        setClasesFiltradas(bloquesFiltrados);
+    };
+
+    const handleFacultadChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const nuevaFacultad = e.target.value;
+        setFacultadSeleccionada(nuevaFacultad);
+        loadData(nuevaFacultad);
+    };
+
+    return (
+        <Container>
+            <h4 className="mb-3">
+                {facultades.find(f => f.id === facultadSeleccionada)?.nombre || 'Plan de Estudios'}
+            </h4>
+            <Form>
+                <Row>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="facultadId">Facultad</Label>
+                            <Input
+                                id="facultadId"
+                                name="facultad"
+                                type="select"
+                                value={facultadSeleccionada}
+                                onChange={handleFacultadChange}
+                            >
+                                {facultades.map(facultad => (
+                                    <option key={facultad.id} value={facultad.id}>
+                                        {facultad.nombre}
+                                    </option>
+                                ))}
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="periodoId">Periodo</Label>
+                            <Input
+                                id="periodoId"
+                                name="periodo"
+                                type="select"
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="filtroClaseId">Buscar Clase</Label>
+                            <Input
+                                id="filtroClaseId"
+                                name="filtroClase"
+                                placeholder="Matemáticas"
+                                type="text"
+                                value={filtroClase}
+                                onChange={handleFiltroChange}
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                    <Col md={6}>
+                        <FormGroup>
+                            <Label for="docenteId">Buscar Docente</Label>
+                            <Input
+                                id="docenteId"
+                                name="docente"
+                                placeholder="cargon"
+                                type="text"
+                            >
+                            </Input>
+                        </FormGroup>
+                    </Col>
+                </Row>
+            </Form>
+
+            {isLoading ? (
+                <div className="text-center my-5">
+                    <Spinner color="primary">
+                        Loading...
+                    </Spinner>
+                </div>
+            ) : (
+                isEmpty(clasesFiltradas) ? (
+                    <NotFound />
+                ) : (
+                    Object.entries(clasesFiltradas).map(([bloque, clases]) => (
+                        <Card body key={bloque} className={"mb-4"}>
+                            <Row>
+                                {clases.map((clase) => (
+                                    <Col key={clase.id_clase} md={3} className={"mb-3"}>
+                                        <Card>
+                                            <CardHeader>
+                                                <h6 className={"text-muted mb-0"}> {clase.id_clase} </h6>
+                                                <h5 className="mb-0">{clase.nombre_clase}</h5>
+                                                <h6 className={"text-muted mb-0"}> Créditos: {clase.creditos} </h6>
+                                            </CardHeader>
+                                            <CardFooter>
+                                                <ButtonGroup>
+                                                    <Button color="primary" onClick={() => {/*Implementar creación*/ }}><FontAwesomeIcon icon={faPlus} /> </Button>
+                                                    <Button
+                                                        color={"success"}
+                                                        onClick={() => handleOpenModal('edit', parseInt(bloque), clase)}
+                                                    >
+                                                        <FontAwesomeIcon icon={faEdit} />
+                                                    </Button>
+                                                    <Button
+                                                        color={clase.estado ? "warning" : "info"}
+                                                        onClick={() => handleOpenModal('status', parseInt(bloque), clase)}
+                                                        title={clase.estado ? "Desactivar" : "Activar"}
+                                                    >
+                                                        <FontAwesomeIcon icon={clase.estado ? faBan : faCheck} />
+                                                    </Button>
+                                                </ButtonGroup>
+                                            </CardFooter>
+                                        </Card>
+                                    </Col>
+                                ))}
+                                <Col md={3} className={"mb-3"}>
+                                    <Card>
+                                        <CardHeader>
+                                            <CardTitle tag={"h5"}> AGREGAR CLASE </CardTitle>
+                                        </CardHeader>
+                                        <CardFooter>
+                                            <Button
+                                                color={"primary"}
+                                                onClick={() => handleOpenModal('create', parseInt(bloque))}
+                                            >
+                                                <FontAwesomeIcon icon={faPlus} />
+                                            </Button>
+                                        </CardFooter>
+                                    </Card>
+                                </Col>
+                            </Row>
+                        </Card>
+                    ))
+                )
+            )}
+            <Modal isOpen={modal.isOpen} toggle={handleCloseModal}>
+                <ModalHeader toggle={handleCloseModal}>
+                    {modal.type === 'create' && 'Crear Nueva Clase'}
+                    {modal.type === 'edit' && 'Editar Clase'}
+                    {modal.type === 'status' && 'Cambiar Estado de Clase'}
+                </ModalHeader>
+                <Form onSubmit={handleSubmit}>
+                    <ModalBody>
+                        {modal.type === 'status' ? (
+                            <div className="text-center">
+                                <h5>¿Está seguro que desea {modal.currentClase?.estado ? 'desactivar' : 'activar'} la clase?</h5>
+                                <p className="mb-0">Clase: {modal.currentClase?.nombre_clase}</p>
+                                <p className="mb-0">Código: {modal.currentClase?.id_clase}</p>
+                                <p className="mb-0">Créditos: {modal.currentClase?.creditos}</p>
+                            </div>
+                        ) : (
+                            <>
+                                <FormGroup>
+                                    <Label for="id_clase">Código de Clase</Label>
+                                    <Input
+                                        id="id_clase"
+                                        name="id_clase"
+                                        value={formData.id_clase}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="nombre_clase">Nombre de Clase</Label>
+                                    <Input
+                                        id="nombre_clase"
+                                        name="nombre_clase"
+                                        value={formData.nombre_clase}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="creditos">Créditos</Label>
+                                    <Input
+                                        id="creditos"
+                                        name="creditos"
+                                        type="number"
+                                        value={formData.creditos}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <Label for="id_bloque">Bloque</Label>
+                                    <Input
+                                        id="id_bloque"
+                                        name="id_bloque"
+                                        type="number"
+                                        value={formData.id_bloque}
+                                        onChange={handleInputChange}
+                                        required
+                                    />
+                                </FormGroup>
+                            </>
+                        )}
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button color="secondary" onClick={handleCloseModal}>
+                            Cancelar
+                        </Button>
+                        <Button
+                            color={modal.type === 'status' ? (modal.currentClase?.estado ? 'warning' : 'success') : 'primary'}
+                            type="submit"
+                        >
+                            {modal.type === 'create' && 'Crear'}
+                            {modal.type === 'edit' && 'Guardar'}
+                            {modal.type === 'status' && (modal.currentClase?.estado ? 'Desactivar' : 'Activar')}
+                        </Button>
+                    </ModalFooter>
+                </Form>
+            </Modal>
+        </Container>
+    );
+}

--- a/src/store/_reducer.ts
+++ b/src/store/_reducer.ts
@@ -10,6 +10,7 @@ import { NAME as NAME_USER, Reducer as ReducerUser } from "./slices/users";
 import { NAME as NAME_DOCENTES, Reducer as ReducerDocentes } from "./slices/docentes";
 import { NAME as NAME_TERNAS, Reducer as ReducerTernas } from "./slices/ternas";
 import { NAME as NAME_FACULTAD, Reducer as ReducerFacultad } from "./slices/facultades"
+import { NAME as NAME_PENSUM, Reducer as ReducerPensum } from "./slices/pensums";
 // import { NAME as NAME_FACULTAD, Reducer as ReducerFacultad } from "./slices/facultades";
 
 export default CombineReducers({
@@ -23,5 +24,6 @@ export default CombineReducers({
     [NAME_USER]: ReducerUser,
     [NAME_FACULTAD]: ReducerFacultad,
     [NAME_DOCENTES]: ReducerDocentes,
-    [NAME_TERNAS]: ReducerTernas
+    [NAME_TERNAS]: ReducerTernas,
+    [NAME_PENSUM]: ReducerPensum
 });

--- a/src/store/slices/pensums/_fetchers.ts
+++ b/src/store/slices/pensums/_fetchers.ts
@@ -1,0 +1,64 @@
+import { Type as TypeError } from "../../../Api/namespaces/modalError";
+import { CreateFetchers } from "../../../storeConfig";
+import { NAME } from "./_namespace";
+import { getData, saveData, updateData } from "../../../utilities/Utilities";
+import { TypeUtilities } from "../../../utilities/TypeUtilities";
+import { isError } from "../../../Api/utilsError";
+
+export default CreateFetchers(NAME, {
+  async getClases(params: TypeUtilities) {
+    const response = await getData(params);
+    if (isError<TypeError.ModalError>(response?.error)) {
+      return {
+        clases: response?.data,
+        error: response?.error,
+      };
+    }
+    return {
+      clases: response?.data,
+      error: response?.error,
+    };
+  },
+
+  async getCarreras(params: TypeUtilities) {
+    const response = await getData(params);
+    if (isError<TypeError.ModalError>(response?.error)) {
+      return {
+        carreras: response?.data,
+        error: response?.error,
+      };
+    }
+    return {
+      carreras: response?.data,
+      error: response?.error,
+    };
+  },
+
+  async insertClase(params: TypeUtilities) {
+    const response = await saveData(params);
+    if (isError<TypeError.ModalError>(response?.error)) {
+      return {
+        clases: response?.data,
+        error: response?.error,
+      };
+    }
+    return {
+      clases: response?.data,
+      error: response?.error,
+    };
+  },
+
+  async updateClase(params: TypeUtilities) {
+    const response = await updateData(params);
+    if (isError<TypeError.ModalError>(response?.error)) {
+      return {
+        clases: response?.data,
+        error: response?.error,
+      };
+    }
+    return {
+      clases: response?.data,
+      error: response?.error,
+    };
+  },
+});

--- a/src/store/slices/pensums/_namespace.ts
+++ b/src/store/slices/pensums/_namespace.ts
@@ -1,0 +1,45 @@
+import { CreateActions } from "../../../storeConfig";
+import { Type as TypeModal } from "../../../Api/namespaces/modalError";
+
+export const NAME = "Pensum";
+
+export declare namespace Type {
+  export type ClaseInfo = {
+    id_clase: string;
+    nombre_clase: string;
+    creditos: number;
+    estado: boolean;
+    TipoClase: number;
+  };
+
+  export type CarreraInfo = {
+    id_ccb: number;
+    facultadId: string;
+    id_clase: string;
+    id_bloque: number;
+  };
+}
+
+export declare namespace StorePensum {
+  export type State = {
+    clases: Array<Type.ClaseInfo>;
+    carreras: Array<Type.CarreraInfo>;
+    error: TypeModal.ModalError;
+  };
+}
+
+export const Action = CreateActions<{
+  cleanUserData: void;
+  cleanStore: void;
+  setClases: boolean;
+  setCarreras: boolean;
+}>(NAME, ["cleanStore", "cleanUserData", "setClases", "setCarreras"]);
+
+export const INIT: StorePensum.State = {
+  clases: [],
+  carreras: [],
+  error: {
+    code: 0,
+    message: "",
+  }
+};

--- a/src/store/slices/pensums/_reducers.ts
+++ b/src/store/slices/pensums/_reducers.ts
@@ -1,0 +1,32 @@
+import { CreateReducer } from "../../../storeConfig";
+import { INIT, Action } from "./_namespace";
+import Fetcher from "./_fetchers";
+
+export default CreateReducer(INIT, ({ addCase }) => {
+  addCase(Action.cleanStore, (state) => ({ ...state, ...INIT }));
+  addCase(Action.cleanUserData, (state) => ({
+    ...state,
+    clases: INIT.clases,
+    carreras: INIT.carreras,
+  }));
+  addCase(Fetcher.getClases.fulfilled, (state, { payload }) => ({
+    ...state,
+    clases: JSON.parse(JSON.stringify(payload.clases)),
+    error: JSON.parse(JSON.stringify(payload.error)),
+  }));
+  addCase(Fetcher.getCarreras.fulfilled, (state, { payload }) => ({
+    ...state,
+    carreras: JSON.parse(JSON.stringify(payload.carreras)),
+    error: JSON.parse(JSON.stringify(payload.error)),
+  }));
+  addCase(Fetcher.insertClase.fulfilled, (state, { payload }) => ({
+    ...state,
+    clases: JSON.parse(JSON.stringify(payload.clases)),
+    error: JSON.parse(JSON.stringify(payload.error)),
+  }));
+  addCase(Fetcher.updateClase.fulfilled, (state, { payload }) => ({
+    ...state,
+    clases: JSON.parse(JSON.stringify(payload.clases)),
+    error: JSON.parse(JSON.stringify(payload.error)),
+  }));
+});

--- a/src/store/slices/pensums/_selectors.ts
+++ b/src/store/slices/pensums/_selectors.ts
@@ -1,0 +1,13 @@
+import { CreateSelector } from "../../../storeConfig";
+import type { StoreState } from "../..";
+import type { StorePensum } from "./_namespace";
+
+import { NAME } from "./_namespace";
+
+export default function Selector(store: StoreState): StorePensum.State {
+  return store[NAME];
+}
+
+Selector.getClases = CreateSelector(Selector, (state) => state.clases);
+Selector.getCarreras = CreateSelector(Selector, (state) => state.carreras);
+Selector.getError = CreateSelector(Selector, (state) => state.error);

--- a/src/store/slices/pensums/index.ts
+++ b/src/store/slices/pensums/index.ts
@@ -1,0 +1,6 @@
+export { NAME, INIT, Action } from "./_namespace";
+export type { StorePensum } from "./_namespace";
+
+export { default as Selector } from "./_selectors";
+export { default as Reducer } from "./_reducers";
+export { default as Fetcher } from "./_fetchers";


### PR DESCRIPTION
22.11: [FEATURE] Implementación de vista para gestión de pensums, donde todas las vistas permiten filtrar las clases por facultad y comparten la misma estructura de organización.

Implementación de vista principal de pensums con navegación mediante TabPane que incluye:
- Vista de carreras: Muestra clases regulares (tipo 1) organizadas por bloques académicos
- Vista de laboratorios: Muestra clases de laboratorio (tipo 3)
- Vista de diplomados y coprogramáticas: Muestra diplomados de inglés (tipo 2) y clases coprogramáticas (tipo 4)

Issues relacionados:
UNICAH-ICC-SAP/GestionPracticasWeb/issues/15
UNICAH-ICC-SAP/GestionPracticasWeb/issues/25
